### PR TITLE
Suppress progress bar depending on stdout context

### DIFF
--- a/bin/firebase-import.js
+++ b/bin/firebase-import.js
@@ -27,10 +27,6 @@ var argv = require('optimist')
   .describe('merge', 'Write the top-level children without overwriting the whole parent.')
   .alias('m', 'merge')
 
-  .boolean('static-output')
-  .describe('static-output', 'Suppress progress bar for compatibility reasons.')
-  .alias('s', 'static-output')
-
   .boolean('force')
   .describe('force', 'Don\'t prompt before overwriting data.')
 
@@ -192,7 +188,7 @@ function chunkInternal(ref, json, forceSplit) {
 function ChunkUploader(chunks) {
   this.next = 0;
   this.chunks = chunks;
-  if (argv['static-output']) {
+  if (process.stdout.isTTY) {
       console.log('Importing... (may take a while)');
   } else {
       this.bar = new ProgressBar('Importing [:bar] :percent (:current/:total)', { width: 50, total: chunks.length, incomplete: ' ' });
@@ -220,7 +216,7 @@ ChunkUploader.prototype.uploadNext = function() {
       throw error;
     }
 
-    if (!argv['static-output']) {
+    if (process.stdout.isTTY && self.bar) {
         self.bar.tick();
     }
 

--- a/bin/firebase-import.js
+++ b/bin/firebase-import.js
@@ -189,9 +189,9 @@ function ChunkUploader(chunks) {
   this.next = 0;
   this.chunks = chunks;
   if (process.stdout.isTTY) {
-      console.log('Importing... (may take a while)');
-  } else {
       this.bar = new ProgressBar('Importing [:bar] :percent (:current/:total)', { width: 50, total: chunks.length, incomplete: ' ' });
+  } else {
+      console.log('Importing... (may take a while)');
   }
 }
 


### PR DESCRIPTION
The progress bar module will crash when firebase-import is running from cron or piping the stdout. Also, in some cases the progress bar "animation" can be annoying.