### PR TITLE
Added version number to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "firebase-import",
   "description": "npm config for Firebase Import",
-  "version": "0.0.0",
+  "version": "2.0.0",
   "dependencies": {
     "JSONStream": "^1.2.1",
     "firebase": "^3.4.0",


### PR DESCRIPTION
### Description

Catapult (the internal tool we use to release Firebase JavaScript libraries) now works without the `0.0.0` version placeholder in the `package.json` file. So, we can finally add the actual version numbers back into this file.

### Code sample

N/A