### PR TITLE
fix: fallback to default service account when file is not provided

### DIFF
--- a/src/firebase-import.js
+++ b/src/firebase-import.js
@@ -44,7 +44,7 @@ var argv = require('optimist')
 
 function main() {
   admin.initializeApp({
-    credential: admin.credential.cert(argv.service_account),
+    credential: argv.service_account ? admin.credential.cert(argv.service_account) : admin.credential.applicationDefault(),
     databaseURL: argv.database_url
   });
 


### PR DESCRIPTION
### 
This PR allows the `firebase-import` package to use the default service account whilst executing in GCP environments. 

This removes the need for manually authenticating the CLI and retains the original behaviour

### Original Behaviour
- **No service account provided** - Internal Firebase error (see below)
- **Service Account provided** - CLI executes correctly

### New Behaviour
- **No service account provided** - Fallback to default service account.
- **Service account provided** - CLI uses provided service account

**Internal Firebase Error**
<img width="569" alt="Screenshot 2021-02-15 at 12 46 41" src="https://user-images.githubusercontent.com/4789968/107948578-f5ce3000-6f8b-11eb-928c-a26a806762f4.png">